### PR TITLE
Ignore plugin/autotag.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/plugin/autotag.pyc


### PR DESCRIPTION
As described in the title, required because otherwise the git submodule in my dotfiles repo is marked as dirty.
