### PR TITLE
Should support both python 2 & 3

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -45,6 +45,18 @@ if sys.version < '2.4':
         """ replace missing format_exc() """
         return ''.join(traceback.format_exception(*list(sys.exc_info())))
 
+elif sys.version > '3':
+    import subprocess
+
+    def do_cmd(cmd, cwd):
+        """ Abstract subprocess """
+        p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             cwd=cwd)
+        so = p.communicate()[0]
+        return so.splitlines()
+
+    from traceback import format_exc
+
 else:
     import subprocess
 
@@ -132,6 +144,8 @@ except NameError:
 
 class AutoTag(object):  # pylint: disable=R0902
     """ Class that does auto ctags updating """
+    if sys.version > '3':
+        long = int
     MAXTAGSFILESIZE = long(vim_global("maxTagsFileSize"))
     LOG = LOGGER
 
@@ -223,7 +237,7 @@ class AutoTag(object):  # pylint: disable=R0902
             for l in source:
                 l = l.strip()
                 if self.goodTag(l, sources):
-                    print l
+                    print(l)
         finally:
             source.close()
             try:

--- a/plugin/autotag.vim
+++ b/plugin/autotag.vim
@@ -17,16 +17,36 @@ let g:autotag_vim_version_sourced=s:autotag_vim_version
 " so this script (implemented in python) finds a tags file for the file vim has
 " just saved, removes all entries for that source file and *then* runs ctags -a
 
-if has("python")
+if has("python") || has("python3")
+
+if has("python3")
+	let s:has_python3 = 1
+else
+	let s:has_python3 = 0
+endif
+
 let s:current_file=expand("<sfile>")
+
+if s:has_python3
+python3 << EEOOFF
+import sys, os, vim
+sys.path.insert(0, os.path.dirname(vim.eval("s:current_file")))
+from autotag import autotag
+EEOOFF
+else
 python << EEOOFF
 import sys, os, vim
 sys.path.insert(0, os.path.dirname(vim.eval("s:current_file")))
 from autotag import autotag
 EEOOFF
+endif
 
 function! AutoTag()
-   python autotag()
+   if s:has_python3
+      python3 autotag()
+   else
+      python autotag()
+   endif
    if exists(":TlistUpdate")
       TlistUpdate
    endif
@@ -46,6 +66,6 @@ augroup autotag
    autocmd BufWritePost,FileWritePost * call AutoTag ()
 augroup END
 
-endif " has("python")
+endif " has("python") || has("python3")
 
 " vim:shiftwidth=3:ts=3


### PR DESCRIPTION
Should be able to run with vim with either python 2 or python 3. I have only python3 support, so python2 support should be tested before merging. But I believe it should be without any problems.
