### PR TITLE
Fixing README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -17,11 +17,13 @@ Installation
 ------------
 
 Currently I suggest you simply
-    cd
-    git clone git://github.com/craigemery/vim-autotag.git
-    cd ~/.vim/
-    mkdir -p plugin
-    cp ~/vim-autotag.git/plugin/autotag.vim plugin/
+```
+cd
+git clone git://github.com/craigemery/vim-autotag.git
+cd ~/.vim/
+mkdir -p plugin
+cp ~/vim-autotag.git/plugin/* plugin/
+```
 
 Self-Promotion
 --------------


### PR DESCRIPTION
- Changing the formatting of the installating guide to code block.
- Changing installation instruction to copy both .vim and .py file to
  plugin folder

Signed-off-by: Elad Raz e@eladraz.com
