### PR TITLE
Fix processing of autoTagsDir option

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -149,7 +149,7 @@ class AutoTag(object):  # pylint: disable=R0902
         self.ctags_cmd = vim_global("CtagsCmd")
         self.tags_file = str(vim_global("TagsFile"))
         self.tags_dir = str(vim_global("TagsDir"))
-        self.parents = os.pardir * (len(os.path.split(self.tags_dir)) - 1)
+        self.parents = (os.pardir + os.sep) * (len(os.path.split(self.tags_dir)) - 1)
         self.count = 0
         self.stop_at = vim_global("StopAt")
 
@@ -241,16 +241,17 @@ class AutoTag(object):  # pylint: disable=R0902
         """ Strip all tags for the source file, then re-run ctags in append mode """
         if self.tags_dir:
             sources = [os.path.join(self.parents + s) for s in sources]
+            tags_dir = os.path.join(tags_dir, self.tags_dir)
         self.stripTags(tags_file, sources)
         if self.tags_file:
             cmd = "%s -f %s -a " % (self.ctags_cmd, self.tags_file)
         else:
             cmd = "%s -a " % (self.ctags_cmd,)
         for source in sources:
-            if os.path.isfile(os.path.join(tags_dir, self.tags_dir, source)):
+            if os.path.isfile(os.path.join(tags_dir, source)):
                 cmd += ' "%s"' % source
         AutoTag.LOG.log(1, "%s: %s", tags_dir, cmd)
-        for l in do_cmd(cmd, self.tags_dir or tags_dir):
+        for l in do_cmd(cmd, tags_dir):
             AutoTag.LOG.log(10, l)
 
     def rebuildTagFiles(self):


### PR DESCRIPTION
Hello, craigmery

First of all, thanks for the plugin.

This commit fixes two issues with `g:autotagTagsDir`.

1) I use ctags with fugurive plugin, so I place `tags` file into `.git` subdirectory. I've found out that though that this functionality is available in your plugin  (via g:autotagTagsDir), it does not work. Here is a log, showing the reason (look at `..tst.cpp` filename):

```
INFO:autotag_debug:source = "/home/kamyshev/workspace/personal/test-repo/tst.cpp"
INFO:autotag_debug:drive = "", file = "/home/kamyshev/workspace/personal/test-repo"
INFO:autotag_debug:testing tags_file "/home/kamyshev/workspace/personal/test-repo/.git/tags"
INFO:autotag_debug:Stripping tags for ..tst.cpp from tags file /home/kamyshev/workspace/personal/test-repo/.git/tags
```

2) With this fixed, I've found out that it cannot open `tags` file if `cwd` in vim is not a root project directory.

Here is what I mean. Test project hierarchy is as following:

```
<rootdir>/.git/tags
<rootdir>/tst.cpp
<rootdir>/d1/x.h
```

When we call vim from `<rootdir>` everything is fine. When we call vim from `<rootdir>/d1` (like this: `cd <rootdir>/d1 && vim ./x.h`), we get the following error:

```
WARNING:root:Traceback (most recent call last):
  File "/home/kamyshev/.vim/bundle/vim-autotag/plugin/autotag.py", line 270, in autotag
    at.rebuildTagFiles()
  File "/home/kamyshev/.vim/bundle/vim-autotag/plugin/autotag.py", line 261, in rebuildTagFiles
    self.updateTagsFile(tags_dir, tags_file, sources)
  File "/home/kamyshev/.vim/bundle/vim-autotag/plugin/autotag.py", line 255, in updateTagsFile
    for l in do_cmd(cmd, self.tags_dir or tags_dir):
  File "/home/kamyshev/.vim/bundle/vim-autotag/plugin/autotag.py", line 63, in do_cmd
    p = subprocess.Popen(cmd, cwd=cwd, **kw)
  File "/usr/lib/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1343, in _execute_child
    raise child_exception
OSError: [Errno 2] Нет такого файла или каталога: '.git'
```

The reason is that though self.tags_dir does not contain a full path to tags file this value is used
as cwd argument when calling ctags application.

