### PR TITLE
Don't update tags no valid file exists

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -246,9 +246,13 @@ class AutoTag(object):  # pylint: disable=R0902
             cmd = "%s -f %s -a " % (self.ctags_cmd, self.tags_file)
         else:
             cmd = "%s -a " % (self.ctags_cmd,)
-        for source in sources:
-            if os.path.isfile(os.path.join(tags_dir, self.tags_dir, source)):
-                cmd += ' "%s"' % source
+
+        args = ["%s" % source for source in sources if os.path.isfile(os.path.join(tags_dir, self.tags_dir, source))]
+        if not args:
+            return
+
+        cmd += ' ' + ' '.join(args)
+
         AutoTag.LOG.log(1, "%s: %s", tags_dir, cmd)
         for l in do_cmd(cmd, self.tags_dir or tags_dir):
             AutoTag.LOG.log(10, l)


### PR DESCRIPTION
This can happen in fugitive's buffer (e.g. fugitive:///home/user/my/file.txt) and if that's the only file being changed it would error out