### PR TITLE
Skip autotagging if buffer remote.

### DIFF
--- a/plugin/autotag.vim
+++ b/plugin/autotag.vim
@@ -30,6 +30,9 @@ if has("python") || has("python3")
    endif
 
    function! AutoTag()
+      if exists("b:netrw_method")
+         return
+      endif
       if has("python")
          python  autotag()
       else


### PR DESCRIPTION
#### Fixes #18
* Used `exists("b:netrw_method")` to check if the buffer is remote and
  inaccessible by ctags.