### PR TITLE
Do not update files belong to vim-fugitive.

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -246,9 +246,10 @@ class AutoTag(object):  # pylint: disable=R0902
             cmd = "%s -f %s -a " % (self.ctags_cmd, self.tags_file)
         else:
             cmd = "%s -a " % (self.ctags_cmd,)
-        for source in sources:
-            if os.path.isfile(os.path.join(tags_dir, self.tags_dir, source)):
-                cmd += ' "%s"' % source
+        args = ["%s" % source for source in sources if os.path.isfile(os.path.join(tags_dir, self.tags_dir, source))]
+        if not args:
+            return
+        cmd += ' ' + ' '.join(args)
         AutoTag.LOG.log(1, "%s: %s", tags_dir, cmd)
         for l in do_cmd(cmd, self.tags_dir or tags_dir):
             AutoTag.LOG.log(10, l)


### PR DESCRIPTION
By default, when save index files belongs to _vim-fugitive_, **autotag** will report an error about "no valid file exist". This patch will fix it.