### PR TITLE
Avoid utf-8 errors

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -214,10 +214,10 @@ class AutoTag(object):  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def good_tag(line, excluded):
         """ Filter method for stripping tags """
-        if line[0] == '!':
+        if line.startswith(b'!'):
             return True
         else:
-            fields = line.split('\t')
+            fields = line.split(b'\t')
             AutoTag.LOG.log(1, "read tags line:%s", str(fields))
             if len(fields) > 3 and fields[1] not in excluded:
                 return True
@@ -227,12 +227,12 @@ class AutoTag(object):  # pylint: disable=too-many-instance-attributes
         """ Strip all tags for a given source file """
         AutoTag.LOG.info("Stripping tags for %s from tags file %s", ",".join(sources), tags_file)
         backup = ".SAFE"
-        source = fileinput.FileInput(files=tags_file, inplace=True, backup=backup)
+        source = fileinput.FileInput(files=tags_file, inplace=True, backup=backup, mode='rb')
         try:
             for line in source:
                 line = line.strip()
                 if self.good_tag(line, sources):
-                    print(line)
+                    print(line.decode('utf-8', errors='replace'))
         finally:
             source.close()
             try:


### PR DESCRIPTION
With the current master of the plugin, I'm getting an error while updating my `~/.vim` directory's tag files:

```
Error detected while processing function AutoTag:
line    7:
WARNING:root:Traceback (most recent call last):
  File "/home/andrew/.vim/bundle/autotag/plugin/autotag.py", line 271, in autotag
    runner.rebuild_tag_files()
  File "/home/andrew/.vim/bundle/autotag/plugin/autotag.py", line 262, in rebuild_tag_files
    self.update_tags_file(tags_dir, tags_file, sources)
  File "/home/andrew/.vim/bundle/autotag/plugin/autotag.py", line 247, in update_tags_file
    self.strip_tags(tags_file, sources)
  File "/home/andrew/.vim/bundle/autotag/plugin/autotag.py", line 232, in strip_tags
    for line in source:
  File "/usr/lib/python3.7/fileinput.py", line 252, in __next__
    line = self._readline()
  File "/usr/lib/python3.7/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb5 in position 4876: invalid start byte
```

There's some invalid utf8 somewhere in the files (I think it's a `μ` in some plugin test, but not sure if it's only that one), and that throws an error.

Using bytes instead of strings, and then writing it as utf-8 with a "replace" fallback works fine for me at this point. Unfortunately, I understand that it's likely not a good general-purpose solution. Maybe the encoding could be a setting, or the plugin could write the line to the file as bytes somehow? I'm not familiar with python, so I'm not sure what options it provides.

On my side, I'll keep using my own fork for now. If you can think of a reasonable way to fix the problem in general, I'd be open to making changes to the PR.
