### PR TITLE
Consult with sys.executable before searching

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -35,6 +35,10 @@ GLOBALS_DEFAULTS = dict(ExcludeSuffixes="tml.xml.text.txt",
 
 def fix_multiprocessing():
     """ Find a good Python executable to use for multiprocessing.Process """
+    if sys.executable:
+        multiprocessing.set_executable(sys.executable)
+        return
+
     exes = glob.glob(os.path.join(sys.exec_prefix, "python*.exe"))
     win = [exe for exe in exes if exe.endswith("w.exe")]
     if win:


### PR DESCRIPTION
Current implementation of `fix_multiprocessing` would not work on linux
(and probably on most of the other UNIXes) unless in very limited and
far from usual python setups.

On linux it is not expected to have python executable inside
`sys.exec_path`. `sys.exec_path` is just a site-specific directory
prefix where the platform-dependent Python files are installed.

According to the docs, `sys.executable` could (but not guaranteed to)
directly give the python executable running at the moment:

> A string giving the absolute path of the executable binary for the
> Python interpreter, on systems where this makes sense. If Python is
> unable to retrieve the real path to its executable, sys.executable
> will be an empty string or None.

This change consults first with `sys.executable` and passes the result
to `multiprocessing.set_executable` and exists, leaving that fuzzy
searching at the moment only for fairly limited cases where the variable
would be `None` or empty string.