### PR TITLE
Fix filter syntax on update_tags_file

### DIFF
--- a/plugin/autotag.py
+++ b/plugin/autotag.py
@@ -280,7 +280,7 @@ class AutoTag():  # pylint: disable=too-many-instance-attributes
             """ inner """
             return os.path.isfile(os.path.join(tags_dir, self.tags_dir, src))
 
-        srcs = list(filter(sources, is_file))
+        srcs = list(filter(is_file, sources))
         if not srcs:
             return
 


### PR DESCRIPTION
I've updated to the latest version and I noticed some errors on `update_tags_file`.

This small PR fixes the syntax of `filter` function, where is the first parameter the function and the second one is the sequence.