### PR TITLE
Fix double formatting bug

### DIFF
--- a/autoload/autotag.py
+++ b/autoload/autotag.py
@@ -291,7 +291,7 @@ class AutoTag():  # pylint: disable=too-many-instance-attributes
         if not srcs:
             return
 
-        cmd += [f'"{s}"' % s for s in srcs]
+        cmd += [f'"{s}"' for s in srcs]
         cmd = " ".join(cmd)
         with lock:
             self.strip_tags(tags_file, sources)


### PR DESCRIPTION
After updating vim I started getting errors when writing files. The errors pointed to this line. It looks like f-string and % formatting are both happening, and unless every file name is a valid % format placeholder like %s (which I think is unlikely), or sources is an empty list, then it will get the error  "not all arguments converted during string formatting". It looks like this code has been like this for years though, so maybe vim has started showing more errors now? I tried doing similar formatting with different versions of Python and they all threw the same exception.